### PR TITLE
[Tooling] Install Script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ifeq ($(TRAVIS), true)
   endif
 endif
 
-.PHONY: clean assemble bundle unit-test report pre-push analysis sonarqube all
+.PHONY: clean assemble bundle unit-test report pre-push analysis sonarqube release install all
 
 clean:
 	./gradlew clean
@@ -44,5 +44,11 @@ sonarqube:
 analysis: unit-test report sonarqube
 
 pre-push: lint
+
+release:
+	./scripts/release.sh ${FLAVOR} ${BUILD_TYPE}
+
+install:
+	./scripts/install.sh ${FLAVOR} ${BUILD_TYPE}
 
 all: clean lint assemble bundle unit-test report analysis

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@
 
 ### Pre-push checks
 You can enable pre-push hooks by running: `./gradlew installGitHooks` 
-You can add or remove checks by updating the `pre-push` target in the [makefile](Makefile). The following checks are enabled per default:
+You can add or remove checks by updating the `pre-push` target in the [makefile](Makefile). The following checks are 
+enabled per default:
 - linting
 - kotlinter
 - detekt
@@ -41,3 +42,8 @@ Add your `storePassword` and `keyPassword` as an environment variable in Travis 
 ### Local Signing
 You can use the [release.sh](/scripts/release.sh) script to sign your apks or aabs.
 `./scripts/release.sh`
+
+## Tooling
+You can use the [install.sh](/scripts/install.sh) script to easily deploy your apks built using the
+[release.sh](/scripts/release.sh) script.
+ 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+FLAVOR="${1-Production}"
+BUILD_TYPE="${2-Release}"
+
+REPO_DIR="$( cd "$( dirname "$0" )/../" && pwd )"
+
+echo "Installing apk for ${FLAVOR}${BUILD_TYPE}"
+
+ARTIFACT=$(echo "app-${FLAVOR}-${BUILD_TYPE}.apk" | tr '[:upper:]' '[:lower:]')
+
+adb install "$REPO_DIR/app/build/outputs/apk/${FLAVOR}/${BUILD_TYPE}/${ARTIFACT}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -45,7 +45,7 @@ elif [[ "${INPUT}" == "a" ]] ||
   ARTIFACT="apk/${FLAVOR}/${BUILD_TYPE}/"
 else
   echo "Invalid input. Abort"
-  exit 0
+  exit 1
 fi
 
 echo "Creating ${APP_TYPE} for ${FLAVOR}${BUILD_TYPE}"


### PR DESCRIPTION
This introduces `install.sh` for easy deployment to devices in combination with `release.sh`. This resloves #58 