### PR TITLE
[FIX] Codecov.yml Flags

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,20 +10,26 @@ coverage:
   status:
     project:
       default:
-        target: 30%
+        target: 75%
         threshold: 10%
+        flags: unit, integration
+
     patch:
       default:
-        target: 1%
-        threshold: 5%
+        target: 60%
+        threshold: 10%
+        flags: unit, integration
+
     unit:
       target: 20%
       threshold: 5%
       flags: unit
+
     integration:
       target: 20%
       threshold: 5%
-      flags: connected
+      flags: integration
+
     changes: no
 
 flags:


### PR DESCRIPTION
## Fix
This fixes the non-existent flag issue:
- `connected` should be `integration`

## Coverage target bump:
- project 30% -> 75%
- patch 1% -> 60%

## Project/Patch Settings:
This adds flags to each -> unit, integration